### PR TITLE
pass in a callback to open

### DIFF
--- a/src/MenuButton.js
+++ b/src/MenuButton.js
@@ -44,10 +44,13 @@ export default class MenuButton extends React.Component {
 
   _onClose: Bus<void> = kefirBus();
 
-  open() {
+  open(callback?: () => any) {
     if (this.state.opened) return;
     if (this.props.onWillOpen) this.props.onWillOpen();
-    this.setState({opened: true}, this.props.onDidOpen);
+    this.setState({opened: true}, () => {
+      if (this.props.onDidOpen) this.props.onDidOpen();
+      if (callback) callback();
+    });
 
     // Clicking outside of the dropdown or pressing escape should close the
     // dropdown.


### PR DESCRIPTION
When calling open programmatically you may want to take an action after the menu has finished opening. However you ONLY want to do this when calling open on the menu button programmatically. Without a callback to the open function you need to then store some state in the owning component with extra logic on "onDidOpen" which is annoying and error prone.