### PR TITLE
Added a `componentProps` attribute that's passed in

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-menu-list",
-  "version": "6.0.5",
+  "version": "6.1.0",
   "description": "React component for menu lists and submenus",
   "main": "js/index.js",
   "sideEffects": false,

--- a/src/MenuButton.js
+++ b/src/MenuButton.js
@@ -26,6 +26,7 @@ export type Props = {
   positionOptions: FloatAnchorOptions;
   menuZIndex?: string|number;
   ButtonComponent: ReactComponentType<{domRef: ReactRef<any>}>;
+  componentProps?: Object;
 
   children?: ReactNode;
   menu: ReactNode;
@@ -46,6 +47,7 @@ export default class MenuButton extends React.Component<Props, State> {
     positionOptions: PropTypes.object,
     menuZIndex: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     ButtonComponent: PropTypes.func,
+    componentProps: PropTypes.object,
 
     children: PropTypes.node,
     menu: PropTypes.element,
@@ -180,6 +182,7 @@ export default class MenuButton extends React.Component<Props, State> {
             aria-expanded={opened}
             disabled={disabled}
             title={title}
+            {...this.props.componentProps}
           >
             {children}
           </ButtonComponent>

--- a/src/MenuButton.test.js
+++ b/src/MenuButton.test.js
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom';
+import PropTypes from 'prop-types';
 import TestUtils from 'react-dom/test-utils';
 import {MenuButton, Dropdown, MenuList, MenuItem} from '.';
 
@@ -103,6 +104,46 @@ test('closes on outside click', () => {
 
   expect(window.addEventListener.mock.calls.filter(c => c[0] === 'mousedown').length).toBe(1);
   expect(window.removeEventListener.mock.calls.filter(c => c[0] === 'mousedown').length).toBe(1);
+
+  ReactDOM.unmountComponentAtNode(mountPoint);
+});
+
+test('passes componentProps to custom component', () => {
+  const mountPoint = document.createElement('div');
+  /* eslint-ignore-next-line react/prop-types */
+  const CustomButton: Function = ({domNode, customProp}) => {
+    return <button html-custom={customProp} ref={domNode}>btn</button>;
+  };
+  CustomButton.propTypes = {
+    domNode: PropTypes.node,
+    customProp: PropTypes.string
+  };
+
+  const root: MenuButton = (ReactDOM.render(
+    <MenuButton
+      ButtonComponent={CustomButton}
+      componentProps={{ customProp: 'custom-prop' }}
+      menu={
+        <Dropdown>
+          <MenuList>
+            <MenuItem>A</MenuItem>
+            <MenuItem>B</MenuItem>
+          </MenuList>
+        </Dropdown>
+      }
+    >
+      foo button
+    </MenuButton>,
+    mountPoint
+  ): any);
+
+  root.reposition(); // just check this doesn't throw
+
+  const button = TestUtils.findRenderedDOMComponentWithTag(root, 'button');
+  if (!button) throw new Error();
+  expect(TestUtils.scryRenderedComponentsWithType(root, Dropdown).length).toBe(0);
+
+  expect(button.getAttribute('custom')).toBeDefined();
 
   ReactDOM.unmountComponentAtNode(mountPoint);
 });


### PR DESCRIPTION
I have a custom button component that needed properties sent to it:
```
        <MenuButton
          ButtonComponent={ActionableIcon}
          componentProps={{ name: 'sandwich' }}
          menu={
            <Dropdown>
              <MenuList>
                <MenuItem>Hello</MenuItem>
              </MenuList>
            </Dropdown>
          }
        />
```
There wasn't currently a way to send these properties to that custom component, so here's a PR that allows for that.  I've created a test as well.