### PR TITLE
Allow dropdown custom className and style

### DIFF
--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -18,18 +18,13 @@ export default class Dropdown extends React.Component<Props> {
   };
 
   render() {
-    var style = _objectSpread(
-      {},
-      {
-        background: "white",
-        border: "1px solid rgba(0,0,0,.2)",
-        boxShadow: "0 2px 4px rgba(0,0,0,0.2)",
-        padding: "6px 0",
-        style: style,
-      },
-      {},
-      this.props.style || {}
-    );
+    var style = {
+      background: "white",
+      border: "1px solid rgba(0,0,0,.2)",
+      boxShadow: "0 2px 4px rgba(0,0,0,0.2)",
+      padding: "6px 0",
+      ...(this.props.style || {}),
+    };
 
     return (
       <div className={this.props.className} style={style}>

--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -1,26 +1,38 @@
 /* @flow */
 
-import React from 'react';
-import type {Node as ReactNode} from 'react';
-import PropTypes from 'prop-types';
+import React from "react";
+import type { Node as ReactNode } from "react";
+import PropTypes from "prop-types";
 
 type Props = {
-  children?: ReactNode;
+  children?: ReactNode,
+  className?: string,
+  style?: Object,
 };
 
 export default class Dropdown extends React.Component<Props> {
   static propTypes = {
-    children: PropTypes.node
+    children: PropTypes.node,
+    className: PropTypes.string,
+    style: PropTypes.object,
   };
 
   render() {
+    var style = _objectSpread(
+      {},
+      {
+        background: "white",
+        border: "1px solid rgba(0,0,0,.2)",
+        boxShadow: "0 2px 4px rgba(0,0,0,0.2)",
+        padding: "6px 0",
+        style: style,
+      },
+      {},
+      this.props.style || {}
+    );
+
     return (
-      <div style={{
-        background: 'white',
-        border: '1px solid rgba(0,0,0,.2)',
-        boxShadow: '0 2px 4px rgba(0,0,0,0.2)',
-        padding: '6px 0'
-      }}>
+      <div className={this.props.className} style={style}>
         {this.props.children}
       </div>
     );


### PR DESCRIPTION
I needed to add custom styles to the Dropdown component (as it has default style and can't be changed in any way). This makes its styles extendable while maintaining backward-compatibility.