### PR TITLE
Convert MenuButton to render props

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,14 +202,14 @@ MenuItem's onItemChosen callback.
 A MenuButton supports the following props:
 
 * `menu`, `positionOptions`, `menuZIndex`, `menuParentElement`, `onWillOpen`, `onDidOpen`,
- `onWillClose`, `className`, `style`, `openedClassName`, `openedStyle`:
- These work the same as the props on SubMenuItem.
-* `disabled`, `title`: These are passed to the button element.
-* `ButtonComponent`: Optional prop that allows a different component to be used
- instead of an html `<button>`. The component passed here must support a
- `domRef` prop which is passed as a ref to the button's DOM element.
-* `buttonProps`: Optional object that will be merged with the props passed to
- the button component.
+ `onWillClose`: These work the same as the props on SubMenuItem.
+* If `renderButton` is not provided: `className`, `style`, `openedClassName`, `openedStyle`,`disabled`, `title` props are accepted and provided to the default html `<button>` element.
+* `renderButton`: Optional render prop that allows a different component to be used
+ instead of an html `<button>`. `renderButton` is a function with a signature of `(domRef: React.Ref<any>, opened: boolean, onKeyPress: (e: KeyboardEvent) => void, onMouseDown: (e: MouseEvent) => void) => React.Node`
+   * `domRef` is passed as a ref to the button's DOM element in your custom implementation
+   * `opened` is whether the menu is being opened.  Useful if you want the appearance of the button to change in this state
+   * `onKeyPress` must be called when your custom button registers key press events
+   * `onMouseDown` must be called when your custom button registers mouse down events
 
 A MenuButton has the following public methods:
 

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ A MenuButton supports the following props:
 * If `renderButton` is not provided: `className`, `style`, `openedClassName`, `openedStyle`,`disabled`, `title` props are accepted and provided to the default html `<button>` element.
 * `renderButton`: Optional render prop that allows a different component to be used
  instead of an html `<button>`. `renderButton` is a function with a signature of `(domRef: React.Ref<any>, opened: boolean, onKeyPress: (e: KeyboardEvent) => void, onMouseDown: (e: MouseEvent) => void) => React.Node`
-   * `domRef` is passed as a ref to the button's DOM element in your custom implementation
+   * `domRef` must be passed as a ref to the button's DOM element in your custom implementation
    * `opened` is whether the menu is being opened.  Useful if you want the appearance of the button to change in this state
    * `onKeyPress` must be called when your custom button registers key press events
    * `onMouseDown` must be called when your custom button registers mouse down events

--- a/index.d.ts
+++ b/index.d.ts
@@ -98,6 +98,9 @@ export class Dropdown extends React.Component<{}> {
 
 // MenuButton
 
+type RenderProp = (domRef: React.Ref<any>, opened: boolean, onKeyPress: (e: KeyboardEvent) => void, onMouseDown: (e: MouseEvent) => void) => ReactNode;
+
+
 export type MenuButtonProps = {
   className?: string;
   style?: Object;
@@ -105,14 +108,14 @@ export type MenuButtonProps = {
   title?: string;
   openedClassName?: string;
   openedStyle?: Object;
+  children?: ReactNode;
+
+  renderButton?: RenderProp;
 
   positionOptions?: FloatAnchorOptions;
   menuZIndex?: string|number;
   menuParentElement?: HTMLElement;
-  ButtonComponent?: React.ComponentType<{domRef: Ref<HTMLElement>}>;
-  buttonProps?: object;
 
-  children?: ReactNode;
   menu: ReactNode;
   onWillOpen?: () => void;
   onDidOpen?: () => void;

--- a/src/MenuButton.js
+++ b/src/MenuButton.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import React from 'react';
-import type {Ref as ReactRef, Node as ReactNode, ComponentType as ReactComponentType, KeyboardEvent, MouseEvent, RefObject} from 'react';
+import type {Ref as ReactRef, Node as ReactNode, ComponentType as ReactComponentType, KeyboardEvent as ReactKeyboardEvent, MouseEvent as ReactMouseEvent, RefObject as ReactRefObject} from 'react';
 import PropTypes from 'prop-types';
 import FloatAnchor from 'react-float-anchor';
 import type {Options as FloatAnchorOptions} from 'react-float-anchor';
@@ -21,9 +21,17 @@ export type Props = {
   positionOptions: FloatAnchorOptions;
   menuZIndex?: string|number;
   menuParentElement?: HTMLElement;
+
   renderButton?: RenderProp;
 
   children?: ReactNode;
+  className?: string;
+  style: Object,
+  openedClassName?: string;
+  openedStyle?: Object;
+  disabled?: boolean;
+  title?: string;
+
   menu: ReactNode;
   onWillOpen?: () => void;
   onDidOpen?: () => void;
@@ -32,10 +40,18 @@ export type Props = {
 
 export default class MenuButton extends React.Component<Props, State> {
   static propTypes = {
-    children: PropTypes.node,
     positionOptions: PropTypes.object,
     menuZIndex: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    
     renderButton: PropTypes.func,
+
+    className: PropTypes.string,
+    openedClassName: PropTypes.string,
+    children: PropTypes.node,
+    style: PropTypes.object,
+    openedStyle: PropTypes.object,
+    disabled: PropTypes.bool,
+    title: PropTypes.string,
 
     menu: PropTypes.element,
     onWillOpen: PropTypes.func,
@@ -125,7 +141,7 @@ export default class MenuButton extends React.Component<Props, State> {
     }
   }
 
-  _setRef(el: HTMLElement | null, anchorRef: RefObject<HTMLElement>) {
+  _setRef(el: HTMLElement | null, anchorRef: ReactRefObject<HTMLElement>) {
     this._anchorRef = el;
     setRef(anchorRef, el);
   }
@@ -142,9 +158,20 @@ export default class MenuButton extends React.Component<Props, State> {
     const {
       menu,
       positionOptions, menuZIndex,
-      renderButton
+      renderButton, openedStyle, openedClassName,
+      disabled, title
     } = this.props;
     const {opened} = this.state;
+
+    let {style, className} = this.props;
+    if (opened) {
+      if (openedStyle) {
+        style = {...style, ...openedStyle};
+      }
+      if (openedClassName) {
+        className = `${className||''} ${openedClassName}`;
+      }
+    }
 
     return (
       <FloatAnchor
@@ -155,12 +182,16 @@ export default class MenuButton extends React.Component<Props, State> {
         anchor={anchorRef => {
           if (!renderButton) {
             return (
-              <button 
+              <button
+                className={className}
+                style={style}
                 ref={el => this._setRef(el, anchorRef)}
                 aria-haspopup={true}
                 aria-expanded={opened}
                 onKeyPress={e => this._onKeyPress(e)}
                 onMouseDown={e => this._onMouseDown(e)}
+                disabled={disabled}
+                title={title}
               >
                 {this.props.children}
               </button>

--- a/src/MenuButton.js
+++ b/src/MenuButton.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import React from 'react';
-import type {Ref as ReactRef, Node as ReactNode, ComponentType as ReactComponentType} from 'react';
+import type {Ref as ReactRef, Node as ReactNode, ComponentType as ReactComponentType, KeyboardEvent, MouseEvent, RefObject} from 'react';
 import PropTypes from 'prop-types';
 import FloatAnchor from 'react-float-anchor';
 import type {Options as FloatAnchorOptions} from 'react-float-anchor';
@@ -15,19 +15,13 @@ import MenuListInspector from './MenuListInspector';
 type State = {
   opened: boolean;
 };
-export type Props = {
-  className?: string;
-  style?: Object;
-  disabled?: boolean;
-  title?: string;
-  openedClassName?: string;
-  openedStyle?: Object;
 
+type RenderProp = (domRef: ReactRef<any>, opened: boolean, onKeyPress: (e: KeyboardEvent) => void, onMouseDown: (e: MouseEvent) => void) => ReactNode;
+export type Props = {
   positionOptions: FloatAnchorOptions;
   menuZIndex?: string|number;
   menuParentElement?: HTMLElement;
-  ButtonComponent: ReactComponentType<{domRef: ReactRef<any>}>;
-  buttonProps?: Object;
+  renderButton?: RenderProp;
 
   children?: ReactNode;
   menu: ReactNode;
@@ -38,19 +32,11 @@ export type Props = {
 
 export default class MenuButton extends React.Component<Props, State> {
   static propTypes = {
-    className: PropTypes.string,
-    style: PropTypes.object,
-    disabled: PropTypes.bool,
-    title: PropTypes.string,
-    openedClassName: PropTypes.string,
-    openedStyle: PropTypes.object,
-
+    children: PropTypes.node,
     positionOptions: PropTypes.object,
     menuZIndex: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-    ButtonComponent: PropTypes.func,
-    buttonProps: PropTypes.object,
+    renderButton: PropTypes.func,
 
-    children: PropTypes.node,
     menu: PropTypes.element,
     onWillOpen: PropTypes.func,
     onDidOpen: PropTypes.func,
@@ -58,8 +44,7 @@ export default class MenuButton extends React.Component<Props, State> {
   };
 
   static defaultProps = {
-    positionOptions: {position:'bottom', hAlign:'left'},
-    ButtonComponent: ({domRef, ...props}: Object) => <button ref={domRef} {...props} />
+    positionOptions: {position:'bottom', hAlign:'left'}
   };
 
   state: State = {
@@ -67,7 +52,7 @@ export default class MenuButton extends React.Component<Props, State> {
   };
 
   _floatAnchorRef = React.createRef<FloatAnchor>();
-  _anchorEl: ?HTMLElement = null;
+  _anchorRef = React.createRef<HTMLElement>();
   _onClose: Bus<void> = kefirBus();
 
   open(): Promise<void> {
@@ -82,7 +67,7 @@ export default class MenuButton extends React.Component<Props, State> {
         fromEventsCapture(window, 'focus')
       ])
         .filter(e => {
-          const el = this._anchorEl;
+          const el = this._anchorRef;
           for (let node of FloatAnchor.parentNodes(e.target)) {
             if (node === el) return false;
           }
@@ -129,6 +114,22 @@ export default class MenuButton extends React.Component<Props, State> {
     floatAnchor.reposition();
   }
 
+  _onMouseDown(e: MouseEvent) {
+      if (e.button !== 0) return;
+      this.toggle();
+  }
+
+  _onKeyPress(e: KeyboardEvent) {
+    if (e.key === 'Enter' || e.key === ' ') {
+      this.toggle();
+    }
+  }
+
+  _setRef(el: HTMLElement | null, anchorRef: RefObject<HTMLElement>) {
+    this._anchorRef = el;
+    setRef(anchorRef, el);
+  }
+
   _itemChosen() {
     this.close();
   }
@@ -139,22 +140,11 @@ export default class MenuButton extends React.Component<Props, State> {
 
   render() {
     const {
-      children, menu,
+      menu,
       positionOptions, menuZIndex,
-      disabled, title, ButtonComponent
+      renderButton
     } = this.props;
     const {opened} = this.state;
-
-    let style = this.props.style;
-    let className = this.props.className;
-    if (opened) {
-      if (this.props.openedStyle) {
-        style = {...style, ...this.props.openedStyle};
-      }
-      if (this.props.openedClassName) {
-        className = `${className||''} ${this.props.openedClassName}`;
-      }
-    }
 
     return (
       <FloatAnchor
@@ -162,33 +152,22 @@ export default class MenuButton extends React.Component<Props, State> {
         ref={this._floatAnchorRef}
         options={positionOptions}
         zIndex={menuZIndex}
-        anchor={anchorRef =>
-          <ButtonComponent
-            domRef={el => {
-              this._anchorEl = el;
-              setRef(anchorRef, el);
-            }}
-            type="button"
-            className={className}
-            style={style}
-            onMouseDown={e => {
-              if (e.button !== 0) return;
-              this.toggle();
-            }}
-            onKeyPress={e=>{
-              if (e.key === 'Enter' || e.key === ' ') {
-                this.toggle();
-              }
-            }}
-            aria-haspopup={true}
-            aria-expanded={opened}
-            disabled={disabled}
-            title={title}
-            {...this.props.buttonProps}
-          >
-            {children}
-          </ButtonComponent>
-        }
+        anchor={anchorRef => {
+          if (!renderButton) {
+            return (
+              <button 
+                ref={el => this._setRef(el, anchorRef)}
+                aria-haspopup={true}
+                aria-expanded={opened}
+                onKeyPress={e => this._onKeyPress(e)}
+                onMouseDown={e => this._onMouseDown(e)}
+              >
+                {this.props.children}
+              </button>
+            );
+          }
+          return renderButton(el => this._setRef(el, anchorRef), opened, e => this._onKeyPress(e), e => this._onMouseDown(e));
+        }}
         float={
           !opened ? null :
             <MenuListInspector onItemChosen={() => this._itemChosen()}>

--- a/src/MenuButton.js
+++ b/src/MenuButton.js
@@ -152,19 +152,8 @@ export default class MenuButton extends React.Component<Props, State> {
     this.close();
   }
 
-  componentWillUnmount() {
-    this._onClose.emit();
-  }
-
-  render() {
-    const {
-      menu,
-      positionOptions, menuZIndex,
-      renderButton, openedStyle, openedClassName,
-      disabled, title
-    } = this.props;
-    const {opened} = this.state;
-
+  _defaultRenderButton = (domRef: React.Ref<any>, opened: boolean, onKeyPress: (e: KeyboardEvent) => void, onMouseDown: (e: MouseEvent) => void) => {
+    const {openedStyle, openedClassName} = this.props;
     let {style, className} = this.props;
     if (opened) {
       if (openedStyle) {
@@ -176,31 +165,42 @@ export default class MenuButton extends React.Component<Props, State> {
     }
 
     return (
+      <button
+        className={className}
+        style={style}
+        ref={domRef}
+        aria-haspopup={true}
+        aria-expanded={opened}
+        onKeyPress={onKeyPress}
+        onMouseDown={onMouseDown}
+        disabled={this.props.disabled}
+        title={this.props.title}
+      >
+        {this.props.children}
+      </button>
+    );
+  }
+
+  componentWillUnmount() {
+    this._onClose.emit();
+  }
+
+  render() {
+    const {
+      menu,
+      positionOptions, menuZIndex,
+    } = this.props;
+    const {opened} = this.state;
+
+    const renderButton = this.props.renderButton || this._defaultRenderButton;
+
+    return (
       <FloatAnchor
         parentElement={this.props.menuParentElement}
         ref={this._floatAnchorRef}
         options={positionOptions}
         zIndex={menuZIndex}
-        anchor={anchorRef => {
-          if (!renderButton) {
-            return (
-              <button
-                className={className}
-                style={style}
-                ref={el => this._setRef(el, anchorRef)}
-                aria-haspopup={true}
-                aria-expanded={opened}
-                onKeyPress={e => this._onKeyPress(e)}
-                onMouseDown={e => this._onMouseDown(e)}
-                disabled={disabled}
-                title={title}
-              >
-                {this.props.children}
-              </button>
-            );
-          }
-          return renderButton(el => this._setRef(el, anchorRef), opened, e => this._onKeyPress(e), e => this._onMouseDown(e));
-        }}
+        anchor={anchorRef => renderButton(el => this._setRef(el, anchorRef), opened, e => this._onKeyPress(e), e => this._onMouseDown(e))}
         float={
           !opened ? null :
             <MenuListInspector onItemChosen={() => this._itemChosen()}>

--- a/src/MenuButton.js
+++ b/src/MenuButton.js
@@ -1,7 +1,6 @@
 /* @flow */
 
-import React from 'react';
-import type {Ref as ReactRef, Node as ReactNode, ComponentType as ReactComponentType, KeyboardEvent as ReactKeyboardEvent, MouseEvent as ReactMouseEvent, RefObject as ReactRefObject} from 'react';
+import * as React from 'react';
 import PropTypes from 'prop-types';
 import FloatAnchor from 'react-float-anchor';
 import type {Options as FloatAnchorOptions} from 'react-float-anchor';
@@ -16,7 +15,7 @@ type State = {
   opened: boolean;
 };
 
-type RenderProp = (domRef: ReactRef<any>, opened: boolean, onKeyPress: (e: KeyboardEvent) => void, onMouseDown: (e: MouseEvent) => void) => ReactNode;
+type RenderProp = (domRef: React.Ref<any>, opened: boolean, onKeyPress: (e: KeyboardEvent) => void, onMouseDown: (e: MouseEvent) => void) => React.Node;
 export type Props = {
   positionOptions: FloatAnchorOptions;
   menuZIndex?: string|number;
@@ -24,15 +23,15 @@ export type Props = {
 
   renderButton?: RenderProp;
 
-  children?: ReactNode;
+  children?: React.Node;
   className?: string;
-  style: Object,
+  style?: Object,
   openedClassName?: string;
   openedStyle?: Object;
   disabled?: boolean;
   title?: string;
 
-  menu: ReactNode;
+  menu: React.Node;
   onWillOpen?: () => void;
   onDidOpen?: () => void;
   onWillClose?: () => void;
@@ -131,8 +130,11 @@ export default class MenuButton extends React.Component<Props, State> {
   }
 
   _onMouseDown(e: MouseEvent) {
-      if (e.button !== 0) return;
-      this.toggle();
+    if (e.button !== 0) {
+      return;
+    }
+    
+    this.toggle();
   }
 
   _onKeyPress(e: KeyboardEvent) {
@@ -141,7 +143,7 @@ export default class MenuButton extends React.Component<Props, State> {
     }
   }
 
-  _setRef(el: HTMLElement | null, anchorRef: ReactRefObject<HTMLElement>) {
+  _setRef(el: HTMLElement | null, anchorRef: React.Ref<any>) {
     this._anchorRef = el;
     setRef(anchorRef, el);
   }


### PR DESCRIPTION
This converts MenuButton to use renderProps, a more developer-friendly method of programmer-defined component composition than component-as-props.  This is a breaking change, as consumers of react-menu-list will have to change how they implement their menu button usages, but the conversion itself can be done with only a few extra lines of code

This also updates the documentation, which wasn't including documentation about the onKeyDown and onMouseDown event handlers needing to be implemented.

