### PR TITLE
Fix types for events

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -98,7 +98,7 @@ export class Dropdown extends React.Component<{}> {
 
 // MenuButton
 
-type RenderProp = (domRef: React.Ref<any>, opened: boolean, onKeyPress: (e: KeyboardEvent) => void, onMouseDown: (e: MouseEvent) => void) => ReactNode;
+type RenderProp = (domRef: React.Ref<any>, opened: boolean, onKeyPress: (e: React.KeyboardEvent) => void, onMouseDown: (e: React.MouseEvent) => void) => ReactNode;
 
 
 export type MenuButtonProps = {


### PR DESCRIPTION
In #22 I introduced `onKeyPress` and `onMouseDown` render prop arguments, which were using incorrect non-react event types in the index.d.ts.  This PR is to fix those type definitions.